### PR TITLE
Increase JSON max depth from 20 to 100

### DIFF
--- a/PsLogicAppExtractor/functions/Out-TaskFile.ps1
+++ b/PsLogicAppExtractor/functions/Out-TaskFile.ps1
@@ -51,7 +51,7 @@ function Out-TaskFile {
     )
     
     if ($InputObject) {
-        $Content = $InputObject | ConvertTo-Json -Depth 20
+        $Content = $InputObject | ConvertTo-Json -Depth 100
     }
 
     $encoding = New-Object System.Text.UTF8Encoding($true)


### PR DESCRIPTION
Logic apps are notorious for having deep JSON structures and in our case we had several logic apps with truncated JSON output. A warning was displayed for each.

It is still useful to have a max depth to avoid infinite recursion errors.

### Changes
- Change `Out-TaskFile` max depth from 20 to 100
